### PR TITLE
feat: 支持表单

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,8 @@ const { connect, FileType } = require('shimo-js-sdk')
 
 #### 使用示例
 
-假设您的系统有以下接口：
-
-- `POST /files/:fileId/shimo-signature` 返回 `{ signature: '...' }`
-
 ```js
-const { connect, FileType } = require('shimo-js-sdk')
+const { connect } = require('shimo-js-sdk')
 
 const fileId = '1234'
 
@@ -70,58 +66,71 @@ const fileId = '1234'
 const { signature, token } = await getCredentialsFromServer()
 
 connect({
-  appId: '...',
   fileId: fileId,
-  endpoint: 'https://sample-endpoint.shimo.im/',
+  endpoint: 'https://shimo-sdk-endpoint/', // endpoint 因环境而异，请联系技术支持
   signature: signature,
   token: token,
   container: document.querySelector('#shimo-file') // iframe 挂载的目标容器元素
-}).then((shimoSDK) => {
-  // 判断文件类型，也可以在您的系统中记录文件类型
-  if (shimoSDK.fileType === FileType.DocumentPro) {
-    // 通过 shimoSDK.[file_type] 访问对应文件类型的 editor 示例
-
-    // 以获取传统文档评论列表为例
-    shimoSDK.documentPro
-      .getCommentList()
-      .then((comments) => showCommentPanel(comments))
-  }
+}).then((sdk) => {
+  // sdk 即为 ShimoSDK 实例
 })
 ```
 
-#### 对象文档说明
+调用 `connect()` 时，会以传入参数为基础，初始化一个 `<iframe>` 并插入 `container` 对应的元素中。
 
-具体文档请参考 `docs` 目录，此处仅作简单的使用说明。
+返回的 `sdk` 为 `ShimoSDK` 实例，用于和 SDK、编辑器交互。
 
-`connect()`
+### SDK 和编辑器实例
 
-用于生成石墨文档的 `iframe` 链接，并连接，通过 `window.postMessage()` 通信。返回 `ShimoSDK` 对象。
+石墨 JS SDK 共有两种实例用于和 JS SDK 交互：
 
-`ShimoSDK`
+- `ShimoSDK` 由 `connect()` 返回，处理初始化编辑器和编辑器交互的工作
+- `Editor` 文档编辑器，直接和文档内容交互。**`Editor` 所有接口均返回 Promise**
 
-有以下接口：
+两者之间各有独立的方法和事件，具体请查看 `docs` 目录的文档。
 
-`on(事件名，事件回调)` 和 `off(事件名，事件回调)`，用于监听事件：
-
-| 事件       | 参数   | 说明           |
-| ---------- | ------ | -------------- |
-| error      | Error  | 错误事件       |
-| readyState | string | 初始化状态事件 |
-
-- `shimoSDK.documentPro`
-- `shimoSDK.document`
-- `shimoSDK.spreadsheet`
-- `shimoSDK.presentation`
-
-石墨文档编辑器实例，根据不同类型的文件，会使用不同的实例，用于和编辑器通信，如调用接口：`shimoSDK.documentPro.getCommentList()`，**所有接口均返回 Promise**。
-
-`setSignature(signature)` 和 `setToken(token)` 用于更新签名和 token。处于安全考虑，signature 和 token 一般不建议设置太长的过期时间，而为了减少用户长时间未刷新页面，导致 API 请求鉴权失败的情况，可以在 signature 或 token 失效前进行更新。
+获取编辑器实例和与其交互：
 
 ```js
-const { connect, FileType } = require('shimo-js-sdk')
+const { FileType } = require('shimo-js-sdk')
 
-const fileId = '1234'
+// 获取编辑器实例
+const editor = sdk.getEditor()
 
+// 调用通用事件
+editor.on('saveStatusChange', (payload) => {
+  console.log(payload.status)
+})
+
+// 调用特定类型文档的方法
+if (sdk.fileType === FileType.Document) {
+  editor.showHistory()
+}
+```
+
+若为 `TypeScript`，可使用 `Generic`：
+
+```typescript
+const { Document } = require('shimo-js-sdk')
+
+const editor = sdk.getEditor<Document.Editor>()
+editor.on('saveStatusChange', (payload) => {
+  console.log(payload.status)
+})
+
+await editor.showHistory()
+```
+
+### `signature` 和 `token`
+
+- `signature` 为石墨区分请求来源，并实现数据隔离的基础
+- `token` 为您用于识别回调请求来源、是否合法的依据
+
+具体说明请查阅在线文档：[https://platform.shimo.im/v2/docs/concepts/](https://platform.shimo.im/v2/docs/concepts/)。
+
+由于 `signature` 和 `token` 有过期时间，一般也不建议设置过长的时间，但为了减少因过期导致的用户体验问题，`ShimoSDK` 提供 `setCredentials({ signature, token })` 方法用于动态更新。
+
+```js
 // 从您的后端服务获取用于石墨鉴权的签名和 token
 let { signature, token, expires } = await getCredentialsFromServer()
 
@@ -132,7 +141,10 @@ setInterval(
     // 当签名不到一分钟就过期时进行更新
     if (Date.now() - expires < 60000) {
       const resp = await getCredentialsFromServer()
-      shimoSDK.setSignature(resp.signature)
+      await shimoSDK.setCredentials({
+        signature: resp.signature,
+        token: resp.token
+      })
       expires = resp.expires
     }
   },
@@ -140,17 +152,27 @@ setInterval(
 )
 ```
 
-##### 如何和 URL 交互
+### 如何处理 URL
 
 由于石墨 SDK 以 `iframe` 的形式挂载到当前页面，`iframe.src` 对应的 URL 并不适合用于分享，而且在一些功能上，比如 @ 文件，需要用到您系统中对应的 URL 格式，比如 `https://your-domain/files/:id`。
 
 为了解决这个问题，石墨 SDK 引入 `generateUrl()` 和 `openLink()` 方法：
 
 ```js
+import { UrlSharingType } from 'shimo-js-sdk'
+
 const shimoSDK = await connect({
   ...,
 
-  generateUrl(fileId: string): string {
+  generateUrl(fileId: string, info: GenerateUrlInfo): string {
+    if (info?.sharingType === UrlSharingType.FormFill) {
+      return `https://your-domain/files/${fileId}/fill-form`
+    }
+
+    if (info?.sharingType) {
+      return `https://your-domain/files/${fileId} ${info.sharingType}`
+    }
+
     return `https://your-domain/files/${fileId}`
   },
 
@@ -168,7 +190,7 @@ const shimoSDK = await connect({
 })
 ```
 
-###### URL 的上下文信息
+#### URL 的上下文信息
 
 为了在 URL 上传递上下文信息，比如 URL 指向的段落、单元格，在调用 `generateUrl()` 生成 URL 后，会在 URL 后附加一个 `smParams=PARAMS` 的参数：
 
@@ -203,7 +225,36 @@ connect({
 })
 ```
 
-#### 打开表格编辑器时展示指定工作表 (Sheet)
+#### URL Info
+
+`generateUrl(fileId, info)` 中的 `info` 是用于对 URL 进行一些特殊处理的。
+
+`sharingText`：石墨默认提供的分享文本：比如
+
+- `https://your-domain/files/1 xxx 邀请您参与《标题》协作，请复制粘贴后在浏览器打开`
+- `https://your-domain/files/1/fill-form xxx 邀请您填写《标题》表单，……`
+
+`sharingType`：表示此次 `generateUrl()` 对应的行为类型，比如：
+
+- `UrlSharingType.Form` 代表一般的打开编辑表单的行为
+- `UrlSharingType.FormPreview` 代表打开预览表单页面的行为
+- `UrlSharingType.FormFill` 代表打开填写表单页面的行为
+
+您需要根据具体类型，生成不同的 URL，比如：
+
+- `UrlSharingType.Form`、`UrlSharingType.FormPreview` 等一般需要进行鉴权，因此可以用 `/files/${fileId}`
+- `UrlSharingType.FormFill` 填写表单一般不需要登录鉴权，因此可以用另一个独立的路由，比如 `/files/${fileId}/fill-form`
+
+在实际操作中，您可以根据 `sharingType` 按需为 URL 添加分享文本。**若添加了分享文本，则需要您在 `parseUrl()` 中对 URL 进行处理**，比如：
+
+```js
+// url: 'https://your-domain/files/1 xxx 邀请您参与《标题》协作，请复制粘贴后在浏览器打开'
+parseUrl(url: string) {
+  return url.split(' ')[0] // 返回 'https://your-domain/files/1
+}
+```
+
+### 打开表格编辑器时展示指定工作表 (Sheet)
 
 **使用本章节用法时，请先了解 [URL 的上下文信息](#url-的上下文信息) 章节**。
 
@@ -239,7 +290,7 @@ connect({
 })
 ```
 
-#### 打开编辑器时，定位至在正文中 at 某用户的位置
+### 打开编辑器时，定位至在正文中 at 某用户的位置
 
 支持类型：
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as Document from './types/Document'
 import * as Spreadsheet from './types/Spreadsheet'
 import * as Presentation from './types/Presentation'
 import * as Table from './types/Table'
+import * as Form from './types/Form'
 
 export * from 'shimo-js-sdk-shared'
 
@@ -10,4 +11,4 @@ export * from './connect'
 
 export * from './ShimoSDK'
 
-export { DocumentPro, Document, Spreadsheet, Presentation, Table }
+export { DocumentPro, Document, Spreadsheet, Presentation, Table, Form }

--- a/src/types/BaseEditor.ts
+++ b/src/types/BaseEditor.ts
@@ -1,16 +1,30 @@
 export interface EventMap {
-  [key: string]: any
+  /**
+   * 保存状态发生变更
+   */
+  saveStatusDidChange: {
+    /**
+     * @since 22.2.1
+     */
+    status?: 'saving' | 'saved' | 'error'
+  }
 }
 
 export interface BaseEditor<
-  EventMap extends { [K: string]: any } = { [K: string]: any }
+  T extends { [K: string]: any } = { [K: string]: any }
 > {
-  // type preserve hack
-  // __eventMap?: EventMap
-  on: <K extends keyof EventMap>(event: K, handler: EventCallback) => void
-  off: <K extends keyof EventMap>(event: K, handler: EventCallback) => void
-}
+  /**
+   * 监听事件
+   */
+  on: <K extends keyof T>(event: K, handler: (payload: T[K]) => void) => void
 
-export type EventCallback = <K extends keyof EventMap>(
-  payload: EventMap[K]
-) => void
+  /**
+   * 取消监听事件
+   */
+  off: <K extends keyof T>(event: K, handler?: (payload: T[K]) => void) => void
+
+  /**
+   * 设置文档标题
+   */
+  setTitle: (title: string) => Promise<void>
+}

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -7,24 +7,9 @@ interface DocumentErrorMessage {
 
 export interface EventMap extends BaseEventMap {
   /**
-   * 保存状态发生变更
-   */
-  saveStatusChanged: {
-    /**
-     * @since 22.6.1
-     */
-    status?: 'saving' | 'saved' | 'error'
-  }
-
-  /**
    * 标题发生变更
    */
-  titleChange: {
-    /**
-     * 新的标题
-     */
-    title: string
-  }
+  titleChange: string
 
   /**
    * 鼠标移动事件
@@ -106,11 +91,6 @@ export interface Editor extends BaseEditor<EventMap> {
    * @since 22.2.1
    */
   print: (this: Editor, options: {}) => Promise<void>
-
-  /**
-   * 设置文档标题
-   */
-  setTitle: (title: string) => Promise<void>
 
   /**
    * 显示评论侧边栏

--- a/src/types/DocumentPro.ts
+++ b/src/types/DocumentPro.ts
@@ -95,9 +95,7 @@ export interface EventMap extends BaseEventMap {
     commentIds?: string[]
   }
   documentRecalculated: {}
-  saveStatusChanged: {
-    status?: 'saving' | 'saved' | 'error'
-  }
+
   error: {
     /** 错误信息 */
     data?: any
@@ -455,11 +453,6 @@ export interface Editor extends BaseEditor<EventMap> {
   showHistory: (this: Editor, options: {}) => Promise<void>
   /** 关闭历史版本预览 */
   hideHistory: (this: Editor, options: {}) => Promise<void>
-
-  /**
-   * 设置文档标题
-   */
-  setTitle: (title: string) => Promise<void>
 
   /**
    * 更新签名图片

--- a/src/types/Form.ts
+++ b/src/types/Form.ts
@@ -1,0 +1,17 @@
+import { BaseEditor } from './BaseEditor'
+
+export interface EventMap {
+  error: {
+    /** 错误信息 */
+    data?: unknown
+    /** 错误码 */
+    code: number
+  }
+
+  /**
+   * 标题发生变更
+   */
+  titleChange: string
+}
+
+export interface Editor extends BaseEditor<EventMap> {}

--- a/src/types/Presentation.ts
+++ b/src/types/Presentation.ts
@@ -1,9 +1,6 @@
 import { BaseEditor } from './BaseEditor'
 
 export interface EventMap {
-  saveStatusChanged: {
-    status?: 'saving' | 'saved' | 'error'
-  }
   error: {
     /** 错误信息 */
     data?: any
@@ -24,9 +21,4 @@ export interface Editor extends BaseEditor<EventMap> {
   startDemonstration: (this: Editor, options: {}) => Promise<void>
   /** 结束本地演示 */
   endDemonstration: (this: Editor, options: {}) => Promise<void>
-
-  /**
-   * 设置文档标题
-   */
-  setTitle: (title: string) => Promise<void>
 }

--- a/src/types/Spreadsheet.ts
+++ b/src/types/Spreadsheet.ts
@@ -28,9 +28,6 @@ export interface DepartmentPermission {
 }
 
 export interface EventMap extends BaseEventMap {
-  saveStatusChanged: {
-    status?: 'saving' | 'saved' | 'error'
-  }
   error: {
     /** 错误信息 */
     data?: any
@@ -213,11 +210,6 @@ export interface Editor extends BaseEditor<EventMap> {
    * 指定工作表是否可见，不传值为当前工作表
    */
   isSheetVisible: (options?: { sheetId?: string }) => Promise<boolean>
-
-  /**
-   * 设置表格标题，仅用于 UI 展示数据，不触发保存操作
-   */
-  setTitle: (title: string) => Promise<void>
 }
 
 /**

--- a/src/types/Table.ts
+++ b/src/types/Table.ts
@@ -1,16 +1,6 @@
 import { BaseEditor } from './BaseEditor'
 
 export interface EventMap {
-  /**
-   * 保存状态发生变更
-   */
-  saveStatusDidChange: {
-    /**
-     * @since 22.2.1
-     */
-    status?: 'saving' | 'saved' | 'error'
-  }
-
   error: {
     /** 错误信息 */
     data?: unknown
@@ -32,9 +22,4 @@ export interface Editor extends BaseEditor<EventMap> {
    * 创建版本
    */
   createRevision: (this: Editor, options: {}) => Promise<void>
-
-  /**
-   * 设置文档标题
-   */
-  setTitle: (title: string) => Promise<void>
 }


### PR DESCRIPTION
- 支持表单
- 优化 BaseEditor 使用方式
  - 整合通用事件、方法
- 废弃 editor 实例 properties
- 用 `setCredentials()` 替换 `setSignature()` 和 `setToken()`
- 优化 README